### PR TITLE
Fix for: Cannot modify an unmodifiable list (@GeraldGZ's solution in #53)

### DIFF
--- a/lib/src/docx_entry.dart
+++ b/lib/src/docx_entry.dart
@@ -23,11 +23,7 @@ abstract class DocxEntry {
   void _updateArchive(Archive arch);
 
   void _updateData(Archive arch, List<int> data) {
-    if (_index < 0) {
-      arch.addFile(ArchiveFile(_name, data.length, data));
-    } else {
-      arch.files[_index] = ArchiveFile(_name, data.length, data);
-    }
+    arch.addFile(ArchiveFile(_name, data.length, data));
   }
 }
 


### PR DESCRIPTION
Copied from @GeraldGZ's solution
----
**Solved:**
docx_entry.dart function _updateData in line 25
**old:**
```dart
void _updateData(Archive arch, List<int> data) {
    if (_index < 0) {
      arch.addFile(ArchiveFile(_name, data.length, data));
    } else {
      arch.files[_index] = ArchiveFile(_name, data.length, data);
    }
}
```
**change to:**

```dart
void _updateData(Archive arch, List<int> data) {
      arch.addFile(ArchiveFile(_name, data.length, data));
}
```
because lib "archive" is used and there is a change in archive.dart with new version:

```fsty
class Archive extends IterableBase<ArchiveFile> {
List<ArchiveFile> get files => UnmodifiableListView(_files);    //  <-- problem
```
but the addFile has new behavior:
```
// Adding a file with the same path as one that's already in the archive
// will replace the previous file.
```